### PR TITLE
:children_crossing: fix: 시간대별 예측 승률 domain 수정

### DIFF
--- a/src/features/champ/ChampDetail/ChampDetail.tsx
+++ b/src/features/champ/ChampDetail/ChampDetail.tsx
@@ -239,7 +239,7 @@ const ChampDetail = ({ className, champId }: ChampDetailProps) => {
                     >
                       <CartesianGrid strokeDasharray="3 3" stroke={theme.colors.borderColor} />
                       <XAxis dataKey="time" minTickGap={10} tickMargin={5} />
-                      <YAxis type="number" domain={['auto', 'auto']} />
+                      <YAxis type="number" domain={[30, 65]} />
                       <Tooltip />
                       <Line
                         type="monotone"


### PR DESCRIPTION
## AS-IS
![image](https://user-images.githubusercontent.com/42797995/224504561-3d5567d5-fd74-47aa-b0be-01e2e203232b.png)

## TO-BE
![image](https://user-images.githubusercontent.com/42797995/224504548-ae714e56-b605-4ef9-a734-024bb5ca4100.png)
