### PR TITLE
최소화로 자동 시작이 안되던 버그 수정

### DIFF
--- a/src/main/modules/app/app.module.ts
+++ b/src/main/modules/app/app.module.ts
@@ -24,6 +24,7 @@ export class AppModule {
   readonly ICON = nativeImage.createFromPath(
     `${this.RESOURCES_PATH}/icons/${this.IS_MAC ? 'logo@512.png' : 'logo@256.ico'}`,
   )
+  readonly IS_HIDDEN_LAUNCH = process.argv.includes('--hidden')
 
   // main window
   window: BrowserWindow | null = null
@@ -68,7 +69,10 @@ export class AppModule {
     await app.whenReady()
     this.createTray()
 
-    await this.createWindow()
+    // 자동 시작으로 실행되었을 때는 창을 띄우지 않음
+    if (!this.IS_HIDDEN_LAUNCH) {
+      await this.createWindow()
+    }
   }
 
   async createWindow() {


### PR DESCRIPTION
`process.argv.includes('--hidden')` 코드로 최소화 실행인지 확인 후 메인창 생성하지 않기