### PR TITLE
마이그레이션 동작 방식 변경

### DIFF
--- a/src/main/modules/migration/migration.module.ts
+++ b/src/main/modules/migration/migration.module.ts
@@ -3,7 +3,8 @@ import log from 'electron-log'
 
 import { Module } from '@nestjs/common'
 import AutoLaunch from 'auto-launch'
-import { gt, valid } from 'semver'
+import { omit } from 'lodash'
+import { lte, valid } from 'semver'
 
 import { configStore } from '@main/modules/config/config.store'
 import { migrationStore } from '@main/modules/migration/migration.store'
@@ -11,24 +12,64 @@ import { migrationStore } from '@main/modules/migration/migration.store'
 @Module({})
 export class MigrationModule {
   public static async forRootAsync() {
-    let currentVersion = `v${app.getVersion()}`
+    const currentVersion = `v${app.getVersion()}`
+    const initialInstallationVersion = migrationStore.get('initialInstallationVersion')
+    const isInitialInstallation =
+      !initialInstallationVersion &&
+      !Object.keys(omit(migrationStore.store, ['migratedVersions', 'initialInstallationVersion']))
+        .length
 
-    // 개발 모드에서는 가장 최신 버전으로 마이그레이션
-    if (!app.isPackaged) {
-      const versions = Object.getOwnPropertyNames(this).filter(propertyName => valid(propertyName))
-      const latestVersion = versions.find(version => gt(version, currentVersion))
-      currentVersion = latestVersion || currentVersion
+    let migratedVersions = migrationStore.get('migratedVersions')
+    let executedMigrationVersions = migrationStore.get('executedMigrationVersions')
+
+    // 마이그레이션 스토어가 비어있는 경우
+    if (!migratedVersions || !executedMigrationVersions) {
+      migratedVersions = []
+      executedMigrationVersions = []
+
+      migrationStore.store = {
+        initialInstallationVersion: currentVersion,
+        migratedVersions,
+        executedMigrationVersions,
+      }
     }
 
-    if (!migrationStore.get(currentVersion)) {
-      if (this[currentVersion]) {
-        await this[currentVersion]()
-        log.info(`[Migration Module] Migrated to ${currentVersion}`)
-      } else {
-        log.info(`[Migration Module] Migration for ${currentVersion} not found`)
-      }
+    // 선언된 모든 마이그레이션 불러오기
+    const migrationVersions = Object.getOwnPropertyNames(this).filter(propertyName =>
+      valid(propertyName),
+    )
 
-      migrationStore.set(currentVersion, true)
+    if (isInitialInstallation) {
+      // 초기 설치라면 현재 모든 마이그레이션을 실행할 필요가 없으므로 실행된 것으로 간주
+      migrationStore.set('migratedVersions', migrationVersions)
+    } else {
+      // 초기 설치가 아니라면 마이그레이션 실행
+      const executableMigrationVersions = migrationVersions.filter(version => {
+        const isExecutable = !migratedVersions!.includes(version)
+
+        // 개발 모드라면 버전 비교 없이 실행
+        if (!app.isPackaged) return isExecutable
+
+        // 프로덕션 모드라면 하위 및 같은 버전만 실행
+        return isExecutable && lte(version, currentVersion)
+      })
+
+      // 실행 가능한 마이그레이션이 있다면 실행
+      if (executableMigrationVersions.length) {
+        for (const version of executableMigrationVersions) {
+          try {
+            await this[version]()
+            log.info(`[Migration Module] Migrated to ${currentVersion}`)
+          } catch (error) {
+            log.error(`[Migration Module] ${currentVersion}`, error)
+          }
+        }
+
+        migratedVersions.push(...executableMigrationVersions)
+        executedMigrationVersions.push(...executableMigrationVersions)
+        migrationStore.set('migratedVersions', migratedVersions)
+        migrationStore.set('executedMigrationVersions', executedMigrationVersions)
+      }
     }
 
     return {
@@ -37,7 +78,9 @@ export class MigrationModule {
   }
 
   public static async 'v0.0.5'() {
-    configStore.set('general.openWindowWhenLeagueClientLaunch', true)
+    if (configStore.get('general.openWindowWhenLeagueClientLaunch') === undefined) {
+      configStore.set('general.openWindowWhenLeagueClientLaunch', true)
+    }
 
     if (configStore.get('general.autoLaunch')) {
       const ladaAutoLauncher = new AutoLaunch({
@@ -52,24 +95,48 @@ export class MigrationModule {
   }
 
   public static async 'v0.0.11'() {
-    configStore.set('game.useCurrentPositionChampionData', true)
+    if (configStore.get('game.useCurrentPositionChampionData') === undefined) {
+      configStore.set('game.useCurrentPositionChampionData', true)
+    }
   }
 
   public static async 'v0.0.16'() {
-    configStore.set('general.zoom', 1.0)
+    if (configStore.get('general.zoom') === undefined) {
+      configStore.set('general.zoom', 1.0)
+    }
   }
 
   public static async 'v0.0.17'() {
-    configStore.set('game.statsProvider', 'LOL.PS')
-    configStore.set('game.autoRuneSetting', true)
+    if (configStore.get('game.statsProvider') === undefined) {
+      configStore.set('game.statsProvider', 'LOL.PS')
+    }
+
+    if (configStore.get('game.autoRuneSetting') === undefined) {
+      configStore.set('game.autoRuneSetting', true)
+    }
   }
 
   public static async 'v0.0.18'() {
-    configStore.set('game.autoSummonerSpellSetting', true)
-    configStore.set('game.flashKey', 'F')
+    if (configStore.get('game.autoSummonerSpellSetting') === undefined) {
+      configStore.set('game.autoSummonerSpellSetting', true)
+    }
+
+    if (configStore.get('game.flashKey') === undefined) {
+      configStore.set('game.flashKey', 'F')
+    }
   }
 
   public static async 'v0.0.19'() {
-    configStore.set('general.language', null)
+    if (configStore.get('general.language') === undefined) {
+      configStore.set('general.language', null)
+    }
+  }
+
+  public static async 'v0.0.22'() {
+    const language = configStore.get('general.language') as string | undefined | null
+
+    if (language && !['en_US', 'ko_KR'].includes(language)) {
+      configStore.set('general.language', null)
+    }
   }
 }

--- a/src/main/modules/migration/migration.store.ts
+++ b/src/main/modules/migration/migration.store.ts
@@ -1,6 +1,10 @@
 import Store from 'electron-store'
 
-export type MigrationStoreValues = Record<string, boolean>
+export interface MigrationStoreValues {
+  initialInstallationVersion?: string
+  migratedVersions?: string[]
+  executedMigrationVersions?: string[]
+}
 
 export const migrationStore = new Store<MigrationStoreValues>({
   name: 'migration',


### PR DESCRIPTION
## 이전 방식
- 현재 앱 버전과 동일한 마이그레이션 함수 실행
- 실행 후 실행된 버전 저장
- 이후 실행 안되도록 저장된 버전들 무시

## 이후 방식
- 현재 앱 버전보다 낮거나 동일한 마이그레이션 함수 전부 실행
- 실행 후 실행된 버전 저장
- 이후 실행 안되도록 저장된 버전들 무시
- 앱을 처음 설치한 사용자는 현재 까지 작성된 마이그레이션 함수들 동작 안되도록 처리